### PR TITLE
Correctly install files on 64-bit system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,9 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY ${PACKAGE_NAME})
 
 include(CPack)
 
-set(ConfigPackageLocation lib/cmake/${PACKAGE_NAME})
+set(LIB_SUFFIX "" CACHE STRING "Define suffix of LIB_INSTALL_DIR" )
+set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE STRING "Libraries will be installed to")
+set(ConfigPackageLocation ${LIB_INSTALL_DIR}/cmake/${PACKAGE_NAME})
 
 if(CMAKE_VERSION VERSION_GREATER 2.8.10)
   include(CMakePackageConfigHelpers)
@@ -103,7 +105,7 @@ get_filename_component(LIBFLATARRAY_CMAKE_DIR \${CMAKE_CURRENT_LIST_FILE} PATH)
 set(libflatarray_INCLUDE_DIR \"\${LIBFLATARRAY_CMAKE_DIR}/../../../include\")
 ")
 
-set(ConfigPackageLocation lib/cmake/${PACKAGE_NAME})
+set(ConfigPackageLocation ${LIB_INSTALL_DIR}/cmake/${PACKAGE_NAME})
 install(
   FILES "${CMAKE_CURRENT_BINARY_DIR}/${PACKAGE_NAME}Config.cmake"
   DESTINATION "${ConfigPackageLocation}")


### PR DESCRIPTION
Red Hat/Fedora/CentOS and some other derivatives use /udr/lib64 on 64-bit platform, thus .cmake files are also put underneath /usr/lib64/cmake.

I didn't package libflatarray as a noarch package in Fedora, that means the package is arch-dependant although this "lib" only provides headers currently. But I don't know the feature of this package, I guess you will turn this into a shared library in the future, so I still install *Config.cmake to /usr/lib64 still.

Any opinions?