### PR TITLE
Resolving Build Issues Related to Boost Librariers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ if(SUPPORTS_MARCH_NATIVE AND NOT APPLE)
   set(DEFAULT_FLAGS "${DEFAULT_FLAGS} -march=native")
 endif()
 
+find_package(Boost REQUIRED system)
+
 find_package(CUDA)
 # Force the selection of the NVCC host compiler to circumvent the
 # studid FindCUDA CMake module from resolving symlinks (*wink* ccache


### PR DESCRIPTION
cmake: readded find_package for Boost libraries

The reason is, that the build fails, if Boost is not installed to
/usr/include, but a different path such as /usr/local/include. However,
in order to build the tests, at least the Boost headers are
needed. find_package() sets the Boost_INCLUDE_DIRS variable correctly
and the build works again.

Here's a log of the failed build: http://hawo.net/~ly80toro/lfa_build_log

I'm not very familiar with CMake, so let me know if there's a better solution to this.