### PR TITLE
sph: fixed build issue if Silo enabled

### DIFF
--- a/examples/smoothed_particle_hydrodynamics/CMakeLists.txt
+++ b/examples/smoothed_particle_hydrodynamics/CMakeLists.txt
@@ -2,5 +2,6 @@ find_package(Silo)
 
 if(Silo_FOUND AND WITH_CPP14 AND NOT WITH_CUDA)
   add_executable(sph main.cpp kernels.c)
+  include_directories(${Silo_INCLUDE_DIR})
   target_link_libraries(sph ${Silo_LIBRARY})
 endif()


### PR DESCRIPTION
This patch fixes the following build error, if Silo is found on the
system:

```
Scanning dependencies of target sph
[ 93%] Building CXX object
examples/smoothed_particle_hydrodynamics/CMakeFiles/sph.dir/main.cpp.o
/home/kurt/git/libflatarray/examples/smoothed_particle_hydrodynamics/main.cpp:3:10:
fatal error: 'silo.h' file not found
         ^
1 error generated.
*** Error code 1
```

Problem: the include directory for silo.h was missing. This patch adapts
the CMakeLists.txt accordingly.